### PR TITLE
get_country() - fix bracket position

### DIFF
--- a/R/get-gender.R
+++ b/R/get-gender.R
@@ -50,7 +50,7 @@ get_country <- function (country) {
     if (length (i) != 1) {
 
         i <- grep (paste0 ("^", tolower (country)), tolower (dat$country_text))
-        if (length (i != 1))
+        if (length (i) != 1)
             stop (paste0 ("Country not found; please enter either 2-letter ",
                           "ISO3166 abbreviation or full country name.\n",
                           "See 'list_countries' for details"))


### PR DESCRIPTION
Hi @mpadge - David here 👋🙂🇲🇰

First of all Thank You for this awesome package - i love the idea to try and do the routing via streets named after women.  
Still haven't tried it because actually something else brought me here - i was after something that would give `(name of person, country) -> gender` and, by coincidence, stumbled upon [this issue](https://github.com/lmullen/gender/issues/53) in the `gender` pkg that you opened.  

Got intrigued by this 40K file covering most European countries that you mention (amazing find !) and decided to try it out.  

I tried to use the `get_gender` from your package but hit some errors.
```
# this works as expected
get_gender("Melissa", "de")

# this breaks with error
get_gender("Melissa", "Germany")

# traced it to code in here
genderconsciousrouting:::get_country("Germany")
```

I _think_ you have a small mistake with the positioning of the bracket [here](https://github.com/mpadge/gender-conscious-routing/blob/main/R/get-gender.R#L53).
Right now if you pass e.g. 
 - `country = "Germany"` you would enter the second `if`
 -  get a value for `i` from the `grep` call
 - but then `i != 1` would give most of the time `TRUE` and in case you are after "Great Britain" in the 1st row then it would be `FALSE` - but nevertheless
 - `length(TRUE)` or `length(FALSE)` makes you always end up in the `stop` call  

I _think_ you meant if there are several matches i.e. `length(i) != 1` --> then make the `stop` call and otherwise return successfully.


Thanks again for all your work and packages, I keep an eye on all ROpenSci developments.
Will try to route myself to a bar now with this awesome pkg 😎  